### PR TITLE
Bugfix Action with no Kubectl

### DIFF
--- a/scheduler/applicationprocessor.go
+++ b/scheduler/applicationprocessor.go
@@ -17,7 +17,7 @@ import (
 func ApplicationProcessor(commandFlag configuration.CommandFlag,
 	opt configuration.Options, cluster configuration.ApplicationCluster) *state.Capture {
 
-		//TODO: Remove this state capture stuff, it's clunkys
+	//TODO: Remove this state capture stuff, it's clunkys
 	stateCapture := &state.Capture{
 		ClusterName:     cluster.Name,
 		DeploymentState: make(map[string]state.Details),

--- a/scheduler/applicationprocessor.go
+++ b/scheduler/applicationprocessor.go
@@ -59,22 +59,22 @@ func ApplicationProcessor(commandFlag configuration.CommandFlag,
 					log.Error(err.Error())
 				}
 			}
-			//---------------------------------
-			fileList := []string{}
-			err := filepath.Walk(path.Join(opt.TempVCSPath, remoteVCSRepoName, a.Execute.Kubectl.Path), func(path string, f os.FileInfo, err error) error {
-				fileList = append(fileList, path)
-				return nil
-			})
-			if err != nil {
-				log.Error(err.Error())
+			if a.Execute.Kubectl.Path != "" {
+				fileList := []string{}
+				err := filepath.Walk(path.Join(opt.TempVCSPath, remoteVCSRepoName, a.Execute.Kubectl.Path), func(path string, f os.FileInfo, err error) error {
+					fileList = append(fileList, path)
+					return nil
+				})
+				if err != nil {
+					log.Error(err.Error())
 
+				}
+				err = platform.GenerateDeploymentPlan(restclient,
+					k8siface, fileList, deployment.Application.Namespace, opt, commandFlag)
+				if err != nil {
+					log.Error(err.Error())
+				}
 			}
-			err = platform.GenerateDeploymentPlan(restclient,
-				k8siface, fileList, deployment.Application.Namespace, opt, commandFlag)
-			if err != nil {
-				log.Error(err.Error())
-			}
-			//---------------------------------
 		}
 	}
 	return stateCapture


### PR DESCRIPTION
I want to be able to do:
```
APIVersion: "v1"
Kind: "Application"
Strategy:
- Cluster:
    Name: "gke_beamery-trials_us-east4_beamery-foundation"
    Applications:
    - Application:
        Name: "MyApp"
        Namespace: "apis"
        CreateNamespace: true
        Git: "git@gitlab.com:myCompany/myrepo.git"
        Action:
        - Execute:
            Shell: "sed s/BIG_SECRET/r2d2/g"
        - Execute:
            Shell: "sed s/DEFAULT_URL/my-url/g"
        - Execute:
            Kubectl:
              Path: "deployment/"
```

Current behaviour: if Kubectl.Path is empty (""), it tries to deploy the current folder