### PR TITLE
Add support for multiple kubernetes documents in a single file

### DIFF
--- a/platform/kubernetes.go
+++ b/platform/kubernetes.go
@@ -77,16 +77,19 @@ func GenerateDeploymentPlan(config *rest.Config, k kubernetes.Interface,
 			log.Error("Could not read from file %s", file)
 			continue
 		}
-		//Decode into kubernetes object
-		decode := scheme.Codecs.UniversalDeserializer().Decode
-		obj, kind, err := decode(raw, nil, nil)
-		if err != nil {
-			log.Error(fmt.Sprintf("%s : %s", err.Error(), kind))
-			continue
-		}
-		log.Printf("Decoded Kind: %s", kind.String())
+		documents := strings.Split(string(raw), "---")
+		for i, doc := range documents {
+			//Decode into kubernetes object
+			decode := scheme.Codecs.UniversalDeserializer().Decode
+			obj, kind, err := decode([]byte(doc), nil, nil)
+			if err != nil {
+				log.Error(fmt.Sprintf("%s : %s", err.Error(), kind))
+				continue
+			}
+			log.Printf("Decoded Kind: %s", kind.String())
 
-		kubernetesResources = append(kubernetesResources, obj)
+			kubernetesResources = append(kubernetesResources, obj)
+		}
 	}
 
 	//TODO: Deployment plan printing

--- a/platform/kubernetes.go
+++ b/platform/kubernetes.go
@@ -78,7 +78,7 @@ func GenerateDeploymentPlan(config *rest.Config, k kubernetes.Interface,
 			continue
 		}
 		documents := strings.Split(string(raw), "---")
-		for i, doc := range documents {
+		for _, doc := range documents {
 			//Decode into kubernetes object
 			decode := scheme.Codecs.UniversalDeserializer().Decode
 			obj, kind, err := decode([]byte(doc), nil, nil)


### PR DESCRIPTION
Current behaviour: If we have a Kubernetes file with multiple docs, it will just apply the first one.

Feature: with this code, we are able to apply several docs in the same file, like:
```
apiVersion: v1
kind: ServiceAccount
metadata:
  name: nginx
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: important-app
```
