### PR TITLE
Do not return error when Halt received

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"errors"
+	"fmt"
 	"github.com/AlexsJones/gravitywell/configuration"
 	"github.com/AlexsJones/gravitywell/scheduler/planner"
 	"github.com/AlexsJones/gravitywell/scheduler/planner/standard"
@@ -39,9 +40,9 @@ func (s *Scheduler) Run(commandFlag configuration.CommandFlag,
 		case msg := <-statusWatcher:
 			if msg.Halt() {
 				//Halting
-				log.Fatal("Received halt")
+				fmt.Println("Received halt")
+				return nil
 			}
 		}
 	}
-
 }


### PR DESCRIPTION
`log.Fatal()` calls os.Exit(1)

This makes that everytime I run gravitywell, it returns an error. So when I automate a pipeline, it will return an error when it succeeds

We should call `log.Fatal()` only when there is an error, not all the time by default